### PR TITLE
about: Update Netzwerkstadt -> eigene Räume

### DIFF
--- a/about/index.markdown
+++ b/about/index.markdown
@@ -7,7 +7,7 @@ title: About
 Mit dem Maschinendeck e.V. haben wir uns zum Ziel gesetzt in Trier einen Ort zu schaffen, in dem alle Arten von Nerdkultur ein Zuhause finden können. Ob du coden, löten, Kaffee rösten, Brettspiele spielen oder deine neueste Verschwörungstheorie besprechen willst: im Maschinendeck gibt es einen Platz für dich.
 
 ### Vorbei kommen
-Nachdem wir während unserer Gründungsphase und für die Zeit danach netterweise an der Uni mit Dach, Strom und Internet versorgt wurden, sind wir jetzt einen Schritt weiter und haben eine Abmachung mit der Netzwerkstatt Trier getroffen, die uns eine Mitnutzung der Räumlichkeiten ermöglicht. Das heißt wir sind jetzt deutlich flexibler was Treffen, Events und spontane Hacksessions angeht.
+Nachdem wir während unserer Gründungsphase und für die Zeit danach netterweise an der Uni und später in der Netzwerkstatt Trier mit Dach, Strom und Internet versorgt wurden, sind wir jetzt einen Schritt weiter und haben unsere eigenen Räumlichkeiten angemietet. Das heißt wir sind jetzt deutlich flexibler was Treffen, Events und spontane Hacksessions angeht.
 
 Packt also eure Lieblingshardware ein und besucht uns beim regelmäßigen Chaostreff jeden Mittwoch um 20:00 Uhr in der Güterstr. 74, 54295 Trier!
 


### PR DESCRIPTION
Die About-Seite ist noch vom Stand „wir sind in der Netzwerkstadt“. Hab das mal versucht zu aktuallisieren.