### PR TITLE
fixed broken files

### DIFF
--- a/_posts/2014-10-05-Vortrag-Web-Security.md
+++ b/_posts/2014-10-05-Vortrag-Web-Security.md
@@ -1,5 +1,5 @@
 ---
-title: Vortrag: Web Security
+title: Vortrag&#58; Web Security
 layout: post
 ---
 

--- a/_posts/2015-10-02-Vortrag-Mindool.md
+++ b/_posts/2015-10-02-Vortrag-Mindool.md
@@ -1,5 +1,5 @@
 ---
-title: Vortrag: Mindool - Changing your community one idea at a time
+title: Vortrag&#58; Mindool - Changing your community one idea at a time
 layout: post
 ---
 

--- a/_posts/2015-12-13-Pressespiegel-Freifunk.md
+++ b/_posts/2015-12-13-Pressespiegel-Freifunk.md
@@ -1,5 +1,5 @@
 ---
-title: Pressespiegel: Freifunk
+title: Pressespiegel&#58; Freifunk
 layout: post
 ---
 


### PR DESCRIPTION
Jekyll seems to get very confused about : in titles. It makes the posts always be the newest post and have no title. That behavior is very bad because those posts will get pinned.

This commit fixes the issue by replacing : wich &#58; which renders the same.

If you think this is not an issue: Just take a look at the current maschinendeck.org.